### PR TITLE
Run rooting guide

### DIFF
--- a/.github/workflows/run-rooting-guide.yml
+++ b/.github/workflows/run-rooting-guide.yml
@@ -14,6 +14,6 @@ jobs:
           user: ${{ secrets.USER }}
           password: ${{ secrets.PASSWORD }}
           port: ${{ secrets.PORT }}
-          favorite_team: "replace me"
-          team_one: "replace me"
-          team_two: "replace me"
+          favorite_team: "Northeastern"
+          team_one: "Lamar"
+          team_two: "Lehigh"


### PR DESCRIPTION
To run the rooting guide:

- Edit the `.github/workflows/run-rooting-guide.yml file` with your favorite team, and the two teams you are deciding between to root for.
- The pipeline will automatically run when you push your changes to the branch, where you will see the team to root for printed at the end.